### PR TITLE
Change Image css , to add object-fit:cover

### DIFF
--- a/front/src/components/Image.jsx
+++ b/front/src/components/Image.jsx
@@ -9,6 +9,7 @@ const PostImage = styled.img({
   margin: '10px 0',
 
   cursor: 'pointer',
+  objectFit: 'cover',
 
   '@media (min-width: 768px)': {
     width: '13.5vw',


### PR DESCRIPTION
- replaced content is sized to maintain its aspect ratio while filling the element’s entire content box